### PR TITLE
fix Mqtt half open connections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /config.json
+.vscode/

--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -463,7 +463,11 @@ void AsyncMqttClient::_onPoll(AsyncClient* client) {
 
   // if there is too much time the client has sent a ping request without a response, disconnect client to avoid half open connections
   if (_lastPingRequestTime != 0 && (millis() - _lastPingRequestTime) >= (_keepAlive * 1000 * 2)) {
-    disconnect();
+    disconnect(true);
+    return;
+  }
+  else if(millis() - _lastServerActivity >= (_keepAlive * 1000 * 2)) {
+    disconnect(true);
     return;
   // send ping to ensure the server will receive at least one message inside keepalive window
   } else if (_lastPingRequestTime == 0 && (millis() - _lastClientActivity) >= (_keepAlive * 1000 * 0.7)) {
@@ -674,7 +678,12 @@ bool AsyncMqttClient::_sendDisconnect() {
 
   SEMAPHORE_TAKE(false);
 
-  if (_client.space() < neededSpace) { SEMAPHORE_GIVE(); return false; }
+  if (_client.space() < neededSpace) { 
+    SEMAPHORE_GIVE();
+    _client.close(true);
+    _clear();
+    return false; 
+  }
 
   char fixedHeader[2];
   fixedHeader[0] = AsyncMqttClientInternals::PacketType.DISCONNECT;
@@ -728,6 +737,7 @@ void AsyncMqttClient::disconnect(bool force) {
 
   if (force) {
     _client.close(true);
+    _clear();
   } else {
     _sendDisconnect();
     _disconnectOnPoll = false;


### PR DESCRIPTION
- trigger disconnect after a long period of inactivity from server
- When we call disconnect() without force condition, then if client space is less, it wont disconnect. Because it calls sendDisconnect().
- calling disconnect(); for disconnecting due to no server activity isn't enough. Sometimes, if multiple .connect() is called and some packets are lost in the internet and arrives later. A situation occurs such that, the tcp has been closed and hence pcb is equals to NULL. While the library still think its connected necause the onConnect callback is called a little later.
In Such situation _client.close(); will not do anything since pcb is null, so onDisconnect callback wont be called either. So we also have to call _clear() manually.